### PR TITLE
fix: make standard import stricter to avoid too greedy match

### DIFF
--- a/src/parsers.cjs
+++ b/src/parsers.cjs
@@ -1,4 +1,4 @@
-const standardImport = (flags = 'sgm') => new RegExp('(import)\\s*(.+?)\\s*(from)\\s*[\'"](.+?)[\'"]', flags);
+const standardImport = (flags = 'sgm') => new RegExp('(import)\\s*(.+?)\\s*(from)\\s*[\'"]([\\w@\\-\\./]+?)[\'"]', flags);
 module.exports.standardImport = standardImport;
 
 const dynamicImport = (flags = 'gm') => new RegExp('(import)[(][\'"](.+?)[\'"][)]', flags);

--- a/src/parsers.cjs
+++ b/src/parsers.cjs
@@ -1,4 +1,4 @@
-const standardImport = (flags = 'sgm') => new RegExp('(import)\\s*(.+?)\\s*(from)\\s*[\'"]([\\w@\\-\\./]+?)[\'"]', flags);
+const standardImport = (flags = 'sgm') => new RegExp('(import)\\s*([\\w{},\\n\\s\\[\\]\\*\\.]+?)\\s*(from)\\s*[\'"]([\\w@\\-\\./]+?)[\'"]', flags);
 module.exports.standardImport = standardImport;
 
 const dynamicImport = (flags = 'gm') => new RegExp('(import)[(][\'"](.+?)[\'"][)]', flags);

--- a/tap-snapshots/test/parsers.js.test.cjs
+++ b/tap-snapshots/test/parsers.js.test.cjs
@@ -14,14 +14,14 @@ exports[`test/parsers.js TAP .standardImport() - Multiline "export" values > sho
 `
 
 exports[`test/parsers.js TAP .standardImport() - Multiple import statements concatinated > should be the "export" group 1`] = `
-{ 
+{
             export3,
             export4,
         }
 `
 
 exports[`test/parsers.js TAP .standardImport() - Multiple import statements on new lines > should be the "export" group 1`] = `
-{ 
+{
             export3,
             export4,
         }

--- a/test/parsers.js
+++ b/test/parsers.js
@@ -232,7 +232,6 @@ tap.test('.standardImport() - importStar case', (t) => {
     t.end();
 });
 
-
 tap.test('.dynamicImport() - Single qoutes', (t) => {
     const rx = dynamicImport('m');
     const str = 'var promise = import(\'module-name\');';

--- a/test/parsers.js
+++ b/test/parsers.js
@@ -166,7 +166,7 @@ tap.test('.standardImport() - Multiple import statements on new lines', (t) => {
     const str = `
         import{ export1 }from "module-a";
         import {export2} from"module-b"
-        import { 
+        import {
             export3,
             export4,
         } from "module-c";
@@ -190,7 +190,7 @@ tap.test('.standardImport() - Multiple import statements on new lines', (t) => {
 tap.test('.standardImport() - Multiple import statements concatinated', (t) => {
     const rx = standardImport();
     const str = `
-        import{ export1 }from "module-a";import {export2} from"module-b"import { 
+        import{ export1 }from "module-a";import {export2} from"module-b"import {
             export3,
             export4,
         } from "module-c";
@@ -208,6 +208,14 @@ tap.test('.standardImport() - Multiple import statements concatinated', (t) => {
     t.equal(grp[2][1], 'import', 'should be the "import" group');
     t.matchSnapshot(grp[2][2], 'should be the "export" group');
     t.equal(grp[2][4], 'module-c', 'should be the "module name" group of the 3rd import');
+    t.end();
+});
+
+tap.test('.standardImport() - is lazy', (t) => {
+    const rx = standardImport();
+    const str = 'imported to know which is which from "f asfasdf asdfasdf asdfasdf adsfasdf"';
+    const grp = str.match(rx);
+    t.equal(grp, null, `should not match ${str}`);
     t.end();
 });
 

--- a/test/parsers.js
+++ b/test/parsers.js
@@ -219,6 +219,20 @@ tap.test('.standardImport() - is lazy', (t) => {
     t.end();
 });
 
+tap.test('.standardImport() - importStar case', (t) => {
+    const rx = standardImport('sm');
+    const str = 'importStar:hf,__importDefault:bf,__classPrivateFieldGet:vf,__classPrivateFieldSet:gf,__classPrivateFieldIn:yf}=ho.default;function vo(e){return e}function go(e,t){t===void 0&&(t=vo);var r=[],n=!1,o={read:function(){if(n)throw new Error("Sidecar: could not `read` from an `assigned` medium. `read` could be used only with `useMedium`.");return r.length?r[r.length-1]:e},useMedium:function(i){var a=t(i,n);return r.push(a),function(){r=r.filter(function(l){return l!==a})}},assignSyncMedium:function(i){for(n=!0;r.length;){var a=r;r=[],a.forEach(i)}r={push:function(l){return i(l)},filter:function(){return r}}},assignMedium:function(i){n=!0;var a=[];if(r.length){var l=r;r=[],l.forEach(i),a=r}var s=function(){var u=a;a=[],u.forEach(i)},c=function(){return Promise.resolve().then(s)};c(),r={push:function(u){a.push(u),c()},filter:function(u){return a=a.filter(u),r}}}};return o}function Ze(e,t){return t===void 0&&(t=vo),go(e,t)}function br(e){e===void 0&&(e={});var t=go(null);return t.options=bo({async:!0,ssr:!1},e),t}var Ct=Ze({},function(e){var t=e.target,r=e.currentTarget;return{target:t,currentTarget:r}}),Pt=Ze(),yo=Ze(),xo=br({async:!0});var Ha=[],vr=O.forwardRef(function(t,r){var n,o=O.useState(),i=o[0],a=o[1],l=O.useRef(),s=O.useRef(!1),c=O.useRef(null),u=t.children,f=t.disabled,d=t.noFocusGuards,m=t.persistentFocus,p=t.crossFrame,h=t.autoFocus,v=t.allowTextSelection,g=t.group,y=t.className,w=t.whiteList,E=t.hasPositiveIndices,A=t.shards,I=A===void 0?Ha:A,q=t.as,D=q===void 0?"div":q,N=t.lockProps,S=N===void 0?{}:N,$=t.sideCar,K=t.returnFocus,W=t.focusOptions,M=t.onActivation,V=t.onDeactivation,Ee=O.useState({}),L=Ee[0],Bt=O.useCallback(function(){c.current=c.current||document&&document.activeElement,l.current&&M&&M(l.current),s.current=!0},[M]),jt=O.useCallback(function(){s.current=!1,V&&V(l.current)},[V]);Ma(function(){f||(c.current=null)},[]);var De=O.useCallback(function(z){var ue=c.current;if(ue&&ue.focus){var Wt=typeof K=="function"?K(ue):K;if(Wt){var $r=typeof Wt=="object"?Wt:void 0;c.current=null,z?Promise.resolve().then(function(){return ue.focus($r)}):ue.focus($r)}}},[K]),it=O.useCallback(function(z){s.current&&Ct.useMedium(z)},[]),at=Pt.useMedium,lt=O.useCallback(function(z){l.current!==z&&(l.current=z,a(z))},[]),st=pe((n={},n[wt]=f&&"disabled",n[Xe]=g,n),S),T=d!==!0,U=T&&d!=="tail",ce=pr([r,lt]);return O.createElement(O.Fragment,null,T&&[O.createElement("div",{key:"guard-first","data-focus-guard":!0,tabIndex:f?-1:0,style:Ae}),E?O.createElement("div",{key:"guard-nearest","data-focus-guard":!0,tabIndex:f?-1:1,style:Ae}):null],!f&&O.createElement($,{id:L,sideCar:xo,observed:i,disabled:f,persistentFocus:m,crossFrame:p,autoFocus:h,whiteList:w,shards:I,onActivation:Bt,onDeactivation:jt,returnFocus:De,focusOptions:W}),O.createElement(D,pe({ref:ce},st,{className:y,onBlur:at,onFocus:it}),u),U&&O.createElement("div",{"data-focus-guard":!0,tabIndex:f?-1:0,style:Ae}))});vr.propTypes={};vr.defaultProps={children:void 0,disabled:!1,returnFocus:!1,focusOptions:void 0,noFocusGuards:!1,autoFocus:!0,persistentFocus:!1,crossFrame:!0,hasPositiveIndices:void 0,allowTextSelection:void 0,group:void 0,className:void 0,whiteList:void 0,shards:void 0,as:"div",lockProps:{},onActivation:void 0,onDeactivation:void 0};var gr=vr;import*as jo from"react"';
+    const grp = str.match(rx);
+
+    t.not(grp, null, `should match ${str}`);
+
+    t.equal(grp[1], 'import', 'should be the "import" group');
+    t.equal(grp[2], '*as jo', 'should be the "export" group');
+    t.equal(grp[4], 'react', 'should be the "module name" group');
+    t.end();
+});
+
+
 tap.test('.dynamicImport() - Single qoutes', (t) => {
     const rx = dynamicImport('m');
     const str = 'var promise = import(\'module-name\');';


### PR DESCRIPTION
Experienced a match that started from a comment and matched a good chunk of the file, leading to a syntax error in the produced output.
